### PR TITLE
🎨 Palette: Add accessible text to external links

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
             <a href="https://aireadytips.substack.com" target="_blank" rel="noopener noreferrer" aria-label="Substack" title="Substack">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
                     <path fill="currentColor" d="M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11L22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z"/>
-                </svg>
+                </svg><span class="sr-only">(opens in new tab)</span>
             </a>
         </li>
         <!-- GitHub Icon -->
@@ -136,7 +136,7 @@
             <a href="https://github.com/daley-mottley" target="_blank" rel="noopener noreferrer" aria-label="GitHub" title="GitHub">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.6.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.652.242 2.873.118 3.176.77.84 1.235 1.91 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
-                </svg>
+                </svg><span class="sr-only">(opens in new tab)</span>
             </a>
         </li>
 
@@ -146,7 +146,7 @@
         <li>
             <a href="https://dev.to/daleymottley" target="_blank" rel="noopener noreferrer" aria-label="Dev.to" title="Dev.to">
                 <svg viewBox="0 32 447.99999999999994 448" xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path fill="currentColor" d="M120.12 208.29c-3.88-2.9-7.77-4.35-11.65-4.35H91.03v104.47h17.45c3.88 0 7.77-1.45 11.65-4.35s5.82-7.25 5.82-13.06v-69.65c-.01-5.8-1.96-10.16-5.83-13.06zM404.1 32H43.9C19.7 32 .06 51.59 0 75.8v360.4C.06 460.41 19.7 480 43.9 480h360.2c24.21 0 43.84-19.59 43.9-43.8V75.8c-.06-24.21-19.7-43.8-43.9-43.8zM154.2 291.19c0 18.81-11.61 47.31-48.36 47.25h-46.4V172.98h47.38c35.44 0 47.36 28.46 47.37 47.28zm100.68-88.66H201.6v38.42h32.57v29.57H201.6v38.41h53.29v29.57h-62.18c-11.16.29-20.44-8.53-20.72-19.69V193.7c-.27-11.15 8.56-20.41 19.71-20.69h63.19zm103.64 115.29c-13.2 30.75-36.85 24.63-47.44 0l-38.53-144.8h32.57l29.71 113.72 29.57-113.72h32.58z"/>
-            </svg>
+            </svg><span class="sr-only">(opens in new tab)</span>
             </a>
         </li>
 
@@ -154,7 +154,7 @@
         <li>
             <a href="https://www.linkedin.com/in/daleymottley" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn" title="LinkedIn">                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M19 0H5a5 5 0 0 0-5 5v14a5 5 0 0 0 5 5h14a5 5 0 0 0 5-5V5a5 5 0 0 0-5-5zM8 19H5V8h3v11zM6.5 6.732c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zM20 19h-3v-5.604c0-3.368-4-3.113-4 0V19h-3V8h3v1.765c1.396-2.586 7-2.777 7 2.476V19z"/>
-                </svg>
+                </svg><span class="sr-only">(opens in new tab)</span>
             </a>
         </li>
 
@@ -163,7 +163,7 @@
             <a href="https://x.com/daleymottley" target="_blank" rel="noopener noreferrer" aria-label="Twitter" title="Twitter">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z"/>
-                </svg>
+                </svg><span class="sr-only">(opens in new tab)</span>
             </a>
         </li>
 
@@ -172,7 +172,7 @@
             <a href="https://www.youtube.com/@DaleyMottley" target="_blank" rel="noopener noreferrer" aria-label="YouTube" title="YouTube">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
-                </svg>
+                </svg><span class="sr-only">(opens in new tab)</span>
             </a>
         </li>
 


### PR DESCRIPTION
This pull request adds a visually hidden `<span>` with the text "(opens in new tab)" to all social media links that open in a new browser tab. This improves accessibility by providing necessary context to screen reader users, adhering to WCAG guidelines for predictable navigation.

---
*PR created automatically by Jules for task [11008878055154154293](https://jules.google.com/task/11008878055154154293) started by @daley-mottley*