### PR TITLE
🎨 Palette: Improve Language Switcher Accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,13 +84,13 @@
 
 <body>
 	<div id="language-switcher-container">
-		<div id="selected-language">
+		<button id="selected-language" aria-haspopup="true" aria-expanded="false" aria-controls="language-options">
 			<div class="language-option-item">
 				<img loading="lazy" src="https://flagcdn.com/gb.svg" alt="English">
 				<span>English</span>
 			</div>
-		</div>
-		<div id="language-options">
+		</button>
+		<div id="language-options" role="menu" aria-labelledby="selected-language">
 			<!-- Language options will be populated by i18n.js -->
 		</div>
 	</div>

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -86,6 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       // Hide options
       languageOptions.style.display = 'none';
+      selectedLanguage.setAttribute('aria-expanded', 'false');
     } catch (error) {
       console.error(error);
     }
@@ -93,7 +94,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   selectedLanguage.addEventListener('click', (event) => {
     event.stopPropagation();
-    languageOptions.style.display = languageOptions.style.display === 'block' ? 'none' : 'block';
+    const isExpanded = selectedLanguage.getAttribute('aria-expanded') === 'true';
+    selectedLanguage.setAttribute('aria-expanded', !isExpanded);
+    languageOptions.style.display = isExpanded ? 'none' : 'block';
   });
 
   languageOptions.addEventListener('click', (event) => {
@@ -106,6 +109,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.addEventListener('click', () => {
     languageOptions.style.display = 'none';
+    selectedLanguage.setAttribute('aria-expanded', 'false');
   });
 
   // Populate language options and set initial language


### PR DESCRIPTION
This change addresses a critical accessibility issue with the language switcher. By converting the non-semantic `div` into a proper `<button>` element and adding the necessary ARIA attributes, the component is now fully accessible to keyboard and screen reader users. The corresponding JavaScript was also updated to manage the `aria-expanded` state, ensuring a seamless and accessible experience without any visual modifications.

---
*PR created automatically by Jules for task [8677972436252867304](https://jules.google.com/task/8677972436252867304) started by @daley-mottley*