### PR TITLE
🎨 Palette: Improve Language Switcher Accessibility

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -644,6 +644,18 @@ article.cardProject {
 
 #selected-language {
     cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+    font: inherit;
+    text-align: inherit;
+}
+
+#selected-language:focus-visible {
+    outline: 2px solid #2c98f0;
+    outline-offset: 2px;
+    border-radius: 4px;
 }
 
 .language-option-item {
@@ -654,8 +666,9 @@ article.cardProject {
     transition: background-color 0.2s;
 }
 
-.language-option-item:hover {
+.language-option-item:hover, .language-option-item:focus {
     background-color: #f0f0f0;
+    outline: none;
 }
 
 .language-option-item img {
@@ -679,7 +692,9 @@ article.cardProject {
     border-radius: 4px;
     box-shadow: 0 0 10px rgba(0,0,0,0.1);
     padding: 5px;
-		min-width: 150px;
+    min-width: 150px;
+    list-style: none;
+    margin: 0;
 }
 
 @media screen and (max-width: 768px) {

--- a/index.html
+++ b/index.html
@@ -84,15 +84,15 @@
 
 <body>
 	<div id="language-switcher-container">
-		<div id="selected-language">
+		<button id="selected-language" class="language-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Select language">
 			<div class="language-option-item">
 				<img loading="lazy" src="https://flagcdn.com/gb.svg" alt="English">
 				<span>English</span>
 			</div>
-		</div>
-		<div id="language-options">
+		</button>
+		<ul id="language-options" role="listbox">
 			<!-- Language options will be populated by i18n.js -->
-		</div>
+		</ul>
 	</div>
 	<div id="loader-wrapper">
 		<div id="loader"></div>
@@ -822,7 +822,7 @@ My mission is to empower entrepreneurs and companies by creating custom applicat
 																<div class="form-group mb-4">
 																	<label for="name" class="sr-only" data-i18n="contact.name">Name</label>
 																	<input type="text" id="name" name="name"
-																		class="form-control border rounded w-full py-2 px,,9-3"
+																		class="form-control border rounded w-full py-2 px-3"
 																		placeholder="Name" required aria-required="true" data-i18n="contact.name" placeholder-i18n="contact.name">
 																</div>
 																<div class="form-group mb-4">

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -17,20 +17,29 @@ document.addEventListener('DOMContentLoaded', () => {
   const populateLanguageOptions = () => {
     languageOptions.innerHTML = ''; // Clear existing options
     for (const [lang, { name, flag }] of Object.entries(languages)) {
-      const option = document.createElement('div');
-      option.classList.add('language-option-item');
-      option.setAttribute('data-lang', lang);
+      const li = document.createElement('li');
+      li.setAttribute('role', 'none');
+
+      const button = document.createElement('button');
+      button.classList.add('language-option-item');
+      button.setAttribute('data-lang', lang);
+      button.setAttribute('role', 'option');
+      button.style.width = '100%';
+      button.style.background = 'none';
+      button.style.border = 'none';
+      button.style.textAlign = 'left';
 
       const img = document.createElement('img');
       img.src = `https://flagcdn.com/${flag}.svg`;
-      img.alt = name;
+      img.alt = ''; // Decorative, name is in span
 
       const span = document.createElement('span');
       span.textContent = name;
 
-      option.appendChild(img);
-      option.appendChild(span);
-      languageOptions.appendChild(option);
+      button.appendChild(img);
+      button.appendChild(span);
+      li.appendChild(button);
+      languageOptions.appendChild(li);
     }
   };
 
@@ -86,14 +95,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
       // Hide options
       languageOptions.style.display = 'none';
+      selectedLanguage.setAttribute('aria-expanded', 'false');
     } catch (error) {
       console.error(error);
     }
   };
 
+  const toggleOptions = () => {
+    const isExpanded = selectedLanguage.getAttribute('aria-expanded') === 'true';
+    selectedLanguage.setAttribute('aria-expanded', !isExpanded);
+    languageOptions.style.display = isExpanded ? 'none' : 'block';
+  };
+
   selectedLanguage.addEventListener('click', (event) => {
     event.stopPropagation();
-    languageOptions.style.display = languageOptions.style.display === 'block' ? 'none' : 'block';
+    toggleOptions();
   });
 
   languageOptions.addEventListener('click', (event) => {
@@ -106,6 +122,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.addEventListener('click', () => {
     languageOptions.style.display = 'none';
+    selectedLanguage.setAttribute('aria-expanded', 'false');
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      languageOptions.style.display = 'none';
+      selectedLanguage.setAttribute('aria-expanded', 'false');
+      if (document.activeElement.closest('#language-switcher-container')) {
+        selectedLanguage.focus();
+      }
+    }
   });
 
   // Populate language options and set initial language


### PR DESCRIPTION
💡 **What**: Improved the language switcher to be fully keyboard accessible and screen-reader friendly. Also fixed a layout typo in the contact form's Name input.

🎯 **Why**: 
1. The original language switcher used non-semantic `div` elements and only responded to mouse clicks, making it inaccessible to keyboard and screen reader users. 
2. A typo in the contact form's CSS classes (`px,,9-3`) was causing a minor layout glitch.

📸 **Before/After**: 
- **Before**: Language switcher was a `div` with no focus state or ARIA attributes. Menu items were also `div`s.
- **After**: Semantic `<button>` trigger with ARIA attributes. Menu items are now buttons within a semantic `<ul>` listbox. Added a clear focus ring for keyboard users.

♿ **Accessibility**: 
- Used semantic `<button>` for all interactive elements.
- Added `aria-haspopup="listbox"` and dynamic `aria-expanded` state management.
- Implemented `role="listbox"` and `role="option"` for the dropdown menu.
- Added keyboard listener for the `Escape` key to close the menu and return focus to the trigger.
- Added `:focus-visible` styles to ensure high visibility for keyboard navigation without affecting mouse users.

---
*PR created automatically by Jules for task [3760448138994683970](https://jules.google.com/task/3760448138994683970) started by @daley-mottley*