### PR TITLE
🎨 Palette: Enhanced Language Switcher Accessibility

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -644,6 +644,25 @@ article.cardProject {
 
 #selected-language {
     cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    display: flex;
+    align-items: center;
+}
+
+#selected-language:focus-visible {
+    outline: 2px solid #2c98f0;
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
+.language-option-item:focus-visible {
+    outline: 2px solid #2c98f0;
+    outline-offset: -2px;
+    background-color: #f0f0f0;
 }
 
 .language-option-item {
@@ -679,7 +698,9 @@ article.cardProject {
     border-radius: 4px;
     box-shadow: 0 0 10px rgba(0,0,0,0.1);
     padding: 5px;
-		min-width: 150px;
+    min-width: 150px;
+    list-style: none;
+    margin: 5px 0 0 0;
 }
 
 @media screen and (max-width: 768px) {

--- a/index.html
+++ b/index.html
@@ -84,15 +84,15 @@
 
 <body>
 	<div id="language-switcher-container">
-		<div id="selected-language">
-			<div class="language-option-item">
+		<button id="selected-language" aria-haspopup="listbox" aria-expanded="false" aria-label="Select Language" aria-controls="language-options">
+			<span class="language-option-item">
 				<img loading="lazy" src="https://flagcdn.com/gb.svg" alt="English">
 				<span>English</span>
-			</div>
-		</div>
-		<div id="language-options">
+			</span>
+		</button>
+		<ul id="language-options" role="listbox" aria-label="Language options">
 			<!-- Language options will be populated by i18n.js -->
-		</div>
+		</ul>
 	</div>
 	<div id="loader-wrapper">
 		<div id="loader"></div>

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -17,9 +17,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const populateLanguageOptions = () => {
     languageOptions.innerHTML = ''; // Clear existing options
     for (const [lang, { name, flag }] of Object.entries(languages)) {
-      const option = document.createElement('div');
+      const option = document.createElement('li');
       option.classList.add('language-option-item');
       option.setAttribute('data-lang', lang);
+      option.setAttribute('role', 'option');
+      option.setAttribute('tabindex', '0');
 
       const img = document.createElement('img');
       img.src = `https://flagcdn.com/${flag}.svg`;
@@ -86,26 +88,50 @@ document.addEventListener('DOMContentLoaded', () => {
 
       // Hide options
       languageOptions.style.display = 'none';
+      selectedLanguage.setAttribute('aria-expanded', 'false');
     } catch (error) {
       console.error(error);
     }
   };
 
+  const toggleMenu = (show) => {
+    const isVisible = show !== undefined ? !show : languageOptions.style.display === 'block';
+    languageOptions.style.display = isVisible ? 'none' : 'block';
+    selectedLanguage.setAttribute('aria-expanded', !isVisible);
+  };
+
   selectedLanguage.addEventListener('click', (event) => {
     event.stopPropagation();
-    languageOptions.style.display = languageOptions.style.display === 'block' ? 'none' : 'block';
+    toggleMenu();
   });
 
-  languageOptions.addEventListener('click', (event) => {
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && languageOptions.style.display === 'block') {
+      toggleMenu(false);
+      selectedLanguage.focus();
+    }
+  });
+
+  const handleLanguageSelection = (event) => {
     const target = event.target.closest('.language-option-item');
     if (target) {
       const lang = target.getAttribute('data-lang');
       setLanguage(lang);
     }
+  };
+
+  languageOptions.addEventListener('click', handleLanguageSelection);
+  languageOptions.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleLanguageSelection(event);
+    }
   });
 
   document.addEventListener('click', () => {
-    languageOptions.style.display = 'none';
+    if (languageOptions.style.display === 'block') {
+      toggleMenu(false);
+    }
   });
 
   // Populate language options and set initial language


### PR DESCRIPTION
💡 What: Refactored the language switcher to be fully keyboard-accessible and screen-reader friendly.
🎯 Why: The previous implementation used non-semantic `div` elements and only supported click events, making it inaccessible to users who rely on keyboards or assistive technologies.
📸 Before/After: The switcher now uses a semantic `<button>` trigger and a `<ul>` listbox. Focus states are clearly visible with a blue outline, and the menu can be navigated with a keyboard.
♻ Accessibility:
- Replaced `div` with `<button>` for the trigger.
- Added ARIA attributes: `aria-haspopup`, `aria-expanded`, `aria-controls`, `role="listbox"`, `role="option"`.
- Added keyboard support: `Enter`/`Space` to toggle/select, `Escape` to close and return focus.
- Added `tabindex="0"` to options for keyboard focusability.
- Added `:focus-visible` styles for clear visual feedback.

---
*PR created automatically by Jules for task [4801534872360264828](https://jules.google.com/task/4801534872360264828) started by @daley-mottley*